### PR TITLE
data should be nullable

### DIFF
--- a/android/src/main/kotlin/com/christian/christian_picker_image/ChristianPickerImagePlugin.kt
+++ b/android/src/main/kotlin/com/christian/christian_picker_image/ChristianPickerImagePlugin.kt
@@ -76,7 +76,7 @@ class ChristianPickerImagePlugin : MethodCallHandler, PluginRegistry.ActivityRes
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Boolean {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
 
         if (ImagePicker.shouldHandle(requestCode, resultCode, data)) {
             // Get a list of picked images


### PR DESCRIPTION
When used in combination with other plugins that open activities, on Android, there is a crash because the data parameter should be nullable.

This can be reproduced using the [image_cropper](https://github.com/hnvn/flutter_image_cropper) after picking an image:

```kotlin
List<File> images = await ChristianPickerImage.pickImages(maxImages: 1);

if (images.length > 0) {
   var selectedImage = images.first;

  File croppedFile = await ImageCropper.cropImage(...);
}
```

If you cancel the crop, onActivityResult is called for this plugin with a null data Intent:

```logcat
Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter data
 	at com.christian.christian_picker_image.ChristianPickerImagePlugin.onActivityResult(Unknown Source:2)
 	at io.flutter.embedding.engine.FlutterEnginePluginRegistry$FlutterEngineActivityPluginBinding.onActivityResult(FlutterEnginePluginRegistry```